### PR TITLE
Handle default GST rate for items

### DIFF
--- a/backend/app/routes/items.py
+++ b/backend/app/routes/items.py
@@ -26,7 +26,10 @@ def create_item(payload: schemas.ItemCreate, db: Session = Depends(get_db), user
     exists = db.query(models.Item).filter(models.Item.sku == payload.sku).first()
     if exists:
         raise HTTPException(status_code=400, detail="SKU already exists")
-    item = models.Item(**payload.dict())
+    data = payload.dict()
+    if data.get("gst_rate") is None:
+        data.pop("gst_rate")
+    item = models.Item(**data)
     db.add(item)
     db.flush()
     db.refresh(item)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -60,7 +60,7 @@ class ItemBase(BaseModel):
     price: Decimal = Decimal("0.00")
     stock: int = 0
     reorder_point: int = 0
-    gst_rate: Optional[int] = None  # GST percentage: 0,5,12,18,28
+    gst_rate: Optional[int] = Field(default=18)  # GST percentage: 0,5,12,18,28
 
 class ItemCreate(ItemBase):
     pass

--- a/backend/tests/test_items.py
+++ b/backend/tests/test_items.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pathlib
+import pytest
+from fastapi.testclient import TestClient
+
+# Configure test database
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+# Ensure the backend package is importable
+BACKEND_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(BACKEND_DIR))
+
+from app.main import app  # noqa: E402
+from app.database import Base, engine  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    db_file = pathlib.Path("test.db")
+    if db_file.exists():
+        db_file.unlink()
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def test_create_item_default_gst_rate(client):
+    response = client.post("/items/", json={"name": "Test Item", "sku": "SKU-1"})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["gst_rate"] == 18


### PR DESCRIPTION
## Summary
- default item GST rate to 18 in schemas
- skip gst_rate field on create when None
- add regression test for item creation without gst_rate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a15767ac832f8400ad89ccc6fef5