### PR TITLE
feat: configure API base URL via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# BillFinity
+
+## Environment Variables
+
+### Frontend
+- `VITE_API_BASE_URL`: Base URL for the backend API. This value is injected at build
+  time and exposed to the client via `window.BILLFINITY_API`.
+
+When deploying on Vercel, configure this variable in the project settings so the
+build process receives the correct API endpoint.

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,1 +1,4 @@
-window.BILLFINITY_API = "https://billfinity-backend.onrender.com";
+// The API base URL is injected at build time via the VITE_API_BASE_URL environment
+// variable. When no variable is provided we fall back to the previous production
+// URL so local development continues to work without additional configuration.
+window.BILLFINITY_API = import.meta.env.VITE_API_BASE_URL || "https://billfinity-backend.onrender.com";

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "VITE_API_BASE_URL": "@billfinity-api-base-url"
+  }
+}


### PR DESCRIPTION
## Summary
- read API base URL from `VITE_API_BASE_URL` at build time
- document required env var for Vercel
- expose env var to Vercel builds

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest backend/tests/test_items.py::test_create_item_default_gst_rate`

------
https://chatgpt.com/codex/tasks/task_e_68c6b0062c28832f805b8d52febdabc9